### PR TITLE
Improved startup

### DIFF
--- a/bin/lc
+++ b/bin/lc
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-import sys
-import importlib
-
-try:
-    labname = sys.argv.pop(1)
-except IndexError:
-    print('Usage: "lc labname_package [arguments]')
-    exit(1)
-
-try:
-    labpackage = importlib.import_module(labname)
-except ModuleNotFoundError:
-    print(f'Package {labname} not found')
-    exit(1)
-
-# Run CLI
+# Alias for python -m lclib
 from lclib.__main__ import cli
 cli()

--- a/bin/lc_start_linux.sh
+++ b/bin/lc_start_linux.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Stand-alone starting script for remote drivers hosted on a linux machine
+# Environment preparation should be done during login.
+if [ -z "$1" ]
+  then
+    echo "Usage: $0 lab_name driver_name"
+    exit 1
+fi
+if [ -z "$2" ]
+  then
+    echo "Usage: $0 lab_name driver_name"
+    exit 1
+fi
+nohup python -m lclib $1 start $2 > lclib.nohup.out &

--- a/bin/lc_start_windows.bat
+++ b/bin/lc_start_windows.bat
@@ -1,0 +1,19 @@
+@echo off
+
+REM Stand-alone starting script for remote drivers hosted on a Windows machine
+REM Environment preparation should be done during login.
+
+REM Check if the first argument (lab_name) is provided
+IF "%~1"=="" (
+    echo Usage: %~0 lab_name driver_name
+    exit /b 1
+)
+
+REM Check if the second argument (driver_name) is provided
+IF "%~2"=="" (
+    echo Usage: %~0 lab_name driver_name
+    exit /b 1
+)
+
+REM Run the Python module with the provided arguments
+powershell -Command "Invoke-WmiMethod -Path Win32_Process -Name Create -ArgumentList 'python -m lclib %1 start %2'"

--- a/examples/dummylab/bin/dummylc
+++ b/examples/dummylab/bin/dummylc
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+# Alias for python -m
+import dummylab
+from lclib.__main__ import cli
+cli()

--- a/examples/dummylab/setup.py
+++ b/examples/dummylab/setup.py
@@ -24,5 +24,8 @@ setup(
     description='A Dummy Lab Control demonstration',
     package_dir={'dummylab': 'dummylab'},
     packages=['dummylab'],
+    scripts=[
+        'bin/dummylc'
+        ],
     install_requires=REQUIRES
     )

--- a/lclib/__init__.py
+++ b/lclib/__init__.py
@@ -161,7 +161,8 @@ def caller_module():
 def init(lab_name,
          host_ips=None,
          data_path=None,
-         manager_address=None):
+         manager_address=None,
+         spawn_info=None):
     """
     Set up lab parameters.
 
@@ -170,6 +171,11 @@ def init(lab_name,
         host_ips: (dict) Dict of host names and IPs in  the laboratory LAN {hostname1: ip1, hostname2: ip2, ...}
         data_path: Main path to save data (from control node)
         manager_address: the address for the manager.
+        spawn_info: information required to spawn non-local drivers:
+          {driver1_name: {'ssh_user': str or None,
+                          'run_command': command to run on the remote machine to start the driver
+           driver2_name: ...
+          }
     """
     global config, MANAGER_ADDRESS
     BANNER = '*{0:^120}*'
@@ -200,6 +206,9 @@ def init(lab_name,
     # Set other parameters
     config['conf_path'] = conf_path
     config['module'] = parent_module
+
+    # Store spawn information
+    config['spawn_info'] = spawn_info
 
     print(BANNER.format(f'This is {lab_name} (module "{parent_module}")'))
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ setup(
              'lclib.util.frameconsumer'],
     scripts=[
         'bin/lc'
+        'bin/lc_start_linux.sh'
+        'bin/lc_start_windows.bat'
         ],
     install_requires=REQUIRES,
     )


### PR DESCRIPTION
This is an attempt at solving #5. I haven't figured out yet a robust and multi-platform way to spawn a remote process through ssh.

Another issue is that the command `lc` comes with the base library, and thus ignores which lab package to act upon. For now the simplest is to ensure that the lab package has its own `lc` (see `examples/dummylab/bin/dummylc`).