### PR TITLE
Manager split

### DIFF
--- a/bin/lc
+++ b/bin/lc
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-import sys
-import importlib
-
-try:
-    labname = sys.argv.pop(1)
-except IndexError:
-    print('Usage: "lc labname_package [arguments]')
-    exit(1)
-
-try:
-    labpackage = importlib.import_module(labname)
-except ModuleNotFoundError:
-    print(f'Package {labname} not found')
-    exit(1)
-
 # Run CLI
 from lclib.__main__ import cli
 cli()

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -5,31 +5,30 @@ Usage
 Command line uses
 =================
 
- (TODO: Currently broken)
+ (WARNING: incomplete and subject to change!)
+
+In the following we assume that the custom lab package is called `labname`:
 
 * List all proxy drivers that can be started on the current host:
 
-  ``python -m labcontrol list``
+  ``python -m lclib labname list``
 
 * Start one proxy driver. 
 
-  ``python -m labcontrol start [driver]``
+  ``python -m lclib labname start [driver]``
 
   This will work only if ran from the correct host, and the process will continue to run in the shell.
   The benefit for this usage is that it is easy to ctrl-C.
 
-* To start all proxy drivers:
+* Show all currently running proxy drivers:
 
-  ``python -m labcontrol startall``
-
-  This spawns independent processes, so there is no way to interrupt running servers once running.
-  Only proxy servers that match the current host will be spawned.
+  ``python -m lclib labname running``
 
 * Kill one proxy driver:
 
-  ``python -m labcontrol kill [driver]``
+  ``python -m lclab labname kill [driver]``
 
-* Kill all proxies:
+* Kill all drivers:
 
-  ``python -m labcontrol killall``
+  ``python -m lclib labname killall``
 

--- a/examples/dummylab/dummylab/__init__.py
+++ b/examples/dummylab/dummylab/__init__.py
@@ -1,6 +1,32 @@
 """
 Dummy example lab
 
+To test fully (currently):
+* In one terminal, start monitor:
+::
+    python -m lclib dummylab start monitor
+* In another terminal, start experiment manager:
+::
+    python -m lclib dummylab start manager
+* In another terminal, open a python process and instantiate the fake motor controller:
+::
+    import dummylab
+    d = dummylab.dummymotor.DummyControllerInterface()
+    # Will start listening for a conection
+* In another terminal, start the dummymotor driver:
+::
+    python -m lclib dummylab start dummymotor
+* In another terminal, start the dummydetector driver:
+::
+    python -m lclib dummylab start dummydetector
+* Finally, start an interactive python session (or jupyter notebook), and initialize everything:
+::
+    import dummylab
+    dummylab.ui.init()
+
+From this point on, the clients are connected to the drivers, and motion and acquisitions commands can be sent.
+
+
 This file is part of lab-control-lib
 (c) 2023-2024 Pierre Thibault (pthibault@units.it)
 """

--- a/examples/dummylab/dummylab/__init__.py
+++ b/examples/dummylab/dummylab/__init__.py
@@ -3,29 +3,35 @@ Dummy example lab
 
 To test fully (currently):
 * In one terminal, start monitor:
-::
-    python -m lclib dummylab start monitor
+
+  ``python -m lclib dummylab start monitor``
+
 * In another terminal, start experiment manager:
-::
-    python -m lclib dummylab start manager
+
+  ``python -m lclib dummylab start manager``
+
 * In another terminal, open a python process and instantiate the fake motor controller:
+
 ::
     import dummylab
     d = dummylab.dummymotor.DummyControllerInterface()
-    # Will start listening for a conection
+    # Will start listening for a connection
+
 * In another terminal, start the dummymotor driver:
-::
-    python -m lclib dummylab start dummymotor
+
+  ``python -m lclib dummylab start dummymotor``
+
 * In another terminal, start the dummydetector driver:
-::
-    python -m lclib dummylab start dummydetector
+
+  ``python -m lclib dummylab start dummydetector``
+
 * Finally, start an interactive python session (or jupyter notebook), and initialize everything:
+
 ::
     import dummylab
     dummylab.ui.init()
 
 From this point on, the clients are connected to the drivers, and motion and acquisitions commands can be sent.
-
 
 This file is part of lab-control-lib
 (c) 2023-2024 Pierre Thibault (pthibault@units.it)

--- a/examples/dummylab/dummylab/dummydetector.py
+++ b/examples/dummylab/dummylab/dummydetector.py
@@ -9,7 +9,7 @@ import numpy as np
 import time
 import os
 
-from lclib import register_driver, proxycall, proxydevice, manager
+from lclib import register_driver, proxydevice
 from lclib.camera import CameraBase
 
 # BASE_PATH = "C:\\data\\"
@@ -97,12 +97,11 @@ class Dummydetector(CameraBase):
             time.sleep(self.exposure_time)
 
             # Get metadata
-            man = manager.getManager()
-            if man is None:
+            if not self.manager.connected:
                 self.logger.error("Not connected to manager! No metadata will available!")
                 self.metadata = {}
             else:
-                self.metadata = man.return_meta(request_ID=self.name)
+                self.metadata = self.manager.return_meta(request_ID=self.name)
 
             # Read out buffer
             # frame, meta = det.read_buffer() # or whatever

--- a/examples/dummylab/dummylab/dummydetector.py
+++ b/examples/dummylab/dummylab/dummydetector.py
@@ -97,11 +97,11 @@ class Dummydetector(CameraBase):
             time.sleep(self.exposure_time)
 
             # Get metadata
-            if not self.manager.connected:
-                self.logger.error("Not connected to manager! No metadata will available!")
+            if not self.monitor.connected:
+                self.logger.error("Not connected to monitor! No metadata will available!")
                 self.metadata = {}
             else:
-                self.metadata = self.manager.return_meta(request_ID=self.name)
+                self.metadata = self.monitor.return_meta(request_ID=self.name)
 
             # Read out buffer
             # frame, meta = det.read_buffer() # or whatever

--- a/lclib/__init__.py
+++ b/lclib/__init__.py
@@ -73,11 +73,10 @@ _motor_classes = {}   # Dictionary for motor classes (populated when drivers mod
 drivers = {}   # Dictionary for driver instances
 motors = {}    # Dictionary of motor instances
 
-DEFAULT_MANAGER_PORT = 5001
+DEFAULT_MONITOR_PORT = 5001
 DEFAULT_LOG_LEVEL = 20 # logging.INFO
 
 # Global variables set by init()
-MANAGER_ADDRESS = ('control', DEFAULT_MANAGER_PORT)
 config = {}
 
 # Get computer name and IP addresses
@@ -170,7 +169,7 @@ def caller_module():
 def init(lab_name,
          host_ips=None,
          data_path=None,
-         manager_address=None):
+         monitor_address=None):
     """
     Set up lab parameters.
 
@@ -180,7 +179,7 @@ def init(lab_name,
         data_path: Main path to save data (from control node)
         manager_address: the address for the manager.
     """
-    global config, MANAGER_ADDRESS
+    global config
     BANNER = '*{0:^120}*'
 
     #
@@ -257,20 +256,19 @@ def init(lab_name,
         config['data_path'] = data_path
 
     #
-    # Manager address
+    # Monitor address
     #
-    if manager_address is None:
+    if monitor_address is None:
         # Get manager address from config file, or revert to default
-        MANAGER_ADDRESS = config.get('manager_address', (host_ips['control'], DEFAULT_MANAGER_PORT))
-    else:
-        MANAGER_ADDRESS = manager_address
+        monitor_address = config.get('monitor_address', (host_ips['control'], DEFAULT_MONITOR_PORT))
 
-    # Tricky bootstrapping - the address has been set at import
-    manager.Manager.Client.ADDRESS = MANAGER_ADDRESS
-    manager.Manager.Server.ADDRESS = MANAGER_ADDRESS
+    # Register Hub
+    @register_driver
+    @proxydevice(address=monitor_address)
+    class Monitor(monitor.MonitorBase):
+        pass
 
-    config['manager_address'] = MANAGER_ADDRESS
-    logger.debug(f'Manager address: {MANAGER_ADDRESS}')
+    config['hub_address'] = monitor_address
 
     #
     # Identify this computer by matching IP with HOST_IPS
@@ -283,18 +281,14 @@ def init(lab_name,
 
     config['this_host'] = this_host
 
-    #config['package'] =
-    #import inspect
-    #print(inspect.stack())
-
     print('\n'.join([BANNER.format(f"{lab_name} Lab Control"),
                      BANNER.format(f"Running on host '{local_hostname}'"),
                      BANNER.format(f"a.k.a. '{this_host}' with IP {local_ip_list}")
                      ])
           )
 
+from . import monitor
 from . import manager
 from . import base
 from . import camera
 from . import ui
-

--- a/lclib/__init__.py
+++ b/lclib/__init__.py
@@ -165,7 +165,6 @@ def caller_module():
             break
     return parent_module
 
-
 def init(lab_name,
          host_ips=None,
          data_path=None,
@@ -261,14 +260,6 @@ def init(lab_name,
     if monitor_address is None:
         # Get manager address from config file, or revert to default
         monitor_address = config.get('monitor_address', (host_ips['control'], DEFAULT_MONITOR_PORT))
-
-    # Register Hub
-    @register_driver
-    @proxydevice(address=monitor_address)
-    class Monitor(monitor.MonitorBase):
-        pass
-
-    config['hub_address'] = monitor_address
 
     #
     # Identify this computer by matching IP with HOST_IPS

--- a/lclib/__init__.py
+++ b/lclib/__init__.py
@@ -167,7 +167,6 @@ def caller_module():
 
 def init(lab_name,
          host_ips=None,
-         data_path=None,
          monitor_address=None):
     """
     Set up lab parameters.
@@ -245,14 +244,6 @@ def init(lab_name,
         config['host_ips'] = host_ips
 
     assert 'control' in host_ips, 'Mandatory "control" entry missing in "host_ips"!'
-
-    #
-    # Data path
-    #
-    if data_path is None:
-        data_path = config['data_path']
-    else:
-        config['data_path'] = data_path
 
     #
     # Monitor address

--- a/lclib/__main__.py
+++ b/lclib/__main__.py
@@ -157,19 +157,19 @@ def kill(name):
 
 @cli.command(help='Kill all running server proxy.')
 def killall():
-    # First ask manager to kill all other servers
-    d = client_or_None('manager', client_name=f'killer-{lab_info["this_host"]}')
+    # First ask monitor to kill all other servers
+    d = client_or_None('monitor', client_name=f'killer-{lab_info["this_host"]}')
     if not d:
-        click.Abort('Could not connect to manager!')
+        click.Abort('Could not connect to monitor!')
     time.sleep(.5)
     try:
         d.ask_admin(True, True)
         d.killall()
-        # Then kill manager
+        # Then kill monitor
         d.kill_server()
     except AttributeError:
         # For some reason d can still be None at this point.
-        click.Abort('Could not connect to manager!')
+        click.Abort('Could not connect to monitor!')
     except:
         raise
 

--- a/lclib/manager.py
+++ b/lclib/manager.py
@@ -2,13 +2,14 @@
 Management of experiment data, scans, labeling, etc.
 
 The scan structure is inspired from Elettra's storage structure
- - Investigation : highest category (e.g. speckle_long_branch)
- - Experiment : Typically an experiment run (over days, possibly in multiple parts)
- - Scan : (instead of Elettra's "dataset") a numbered (and possibly labeled) dataset
+ * Investigation: highest category (e.g. speckle_long_branch)
+ * Experiment: Typically an experiment run (over days, possibly in multiple parts)
+ * Scan: (instead of Elettra's "dataset") a numbered (and possibly labeled) dataset
 
 This file is part of lab-control-lib
 (c) 2023-2024 Pierre Thibault (pthibault@units.it)
 """
+
 import os
 from datetime import datetime
 
@@ -28,6 +29,7 @@ class ManagerBase(DriverBase):
       * the `proxydevice` decorator, with the appropriate address.
 
     ::
+
         @register_driver
         @proxydevice(address=(IP, PORT))
         class Manager(ManagerBase):

--- a/lclib/manager.py
+++ b/lclib/manager.py
@@ -83,11 +83,6 @@ class ManagerBase(DriverBase):
         self.scan_info = {}
         self.last_scan_info = self.config['last_scan_info']
 
-        # HACK (kind of): On the process where this class is instantiated, getManager must return this instance, not a client.
-        global _client
-        _client.clear()
-        _client.append(self)
-
     @proxycall()
     def start_scan(self, label=None):
         """

--- a/lclib/manager.py
+++ b/lclib/manager.py
@@ -1,7 +1,7 @@
 """
-Management of experiment data, labeling, metadata, etc.
+Management of experiment data, scans, labeling, etc.
 
-The structure is inspired from Elettra's storage structure
+The scan structure is inspired from Elettra's storage structure
  - Investigation : highest category (e.g. speckle_long_branch)
  - Experiment : Typically an experiment run (over days, possibly in multiple parts)
  - Scan : (instead of Elettra's "dataset") a numbered (and possibly labeled) dataset
@@ -11,72 +11,50 @@ This file is part of lab-control-lib
 """
 import os
 from datetime import datetime
-import time
-import threading
 
-from . import (get_config,
-               MANAGER_ADDRESS,
-               _driver_classes,
-               client_or_None,
-               register_driver,
-               proxycall,
-               proxydevice)
-from .util import Future, now
+from . import proxycall, proxydevice
+
+from .util import now
 from .base import DriverBase
-from .logs import logging_muted
-
-logtags = {'type': 'manager',
-           'branch': 'both'
-           }
-
-_client = []
 
 
-def getManager():
+@proxydevice(address=None)
+class ManagerBase(DriverBase):
     """
-    A convenience function to return the current client (or a new one) for the Manager daemon.
-    """
-    if _client and _client[0]:
-        return _client[0]
-    d = client_or_None('manager', admin=False, client_name=f'client-{get_config()["this_host"]}')
-    _client.clear()
-    _client.append(d)
-    return d
+    Management of experiment scan structure.
 
+    Any package has to subclass this class with
+      * the `register_driver` decorator, and
+      * the `proxydevice` decorator, with the appropriate address.
 
-@register_driver
-@proxydevice(address=MANAGER_ADDRESS)
-class Manager(DriverBase):
-    """
-    Management of experiment structures and metadata.
+    ::
+        @register_driver
+        @proxydevice(address=(IP, PORT))
+        class Manager(ManagerBase):
+            pass
+
+    The subclass can be augmented with custom methods decorated with `proxycall`.
     """
 
     # Allowed characters for experiment and investigation names
     _VALID_CHAR = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-:'
 
-    # Interval at which attempts are made at connecting clients
-    CLIENT_LOOP_INTERVAL = 20.
-
     DEFAULT_CONFIG = DriverBase.DEFAULT_CONFIG.copy()
     DEFAULT_CONFIG.update(
                       {'experiment':None,
                        'investigation':None,
-                       'meta_to_save':{},
                        'last_scan_info': {}})
 
-    def __init__(self):
+    def __init__(self, data_path):
         """
-        Metadata manager for investigations, experiments and scans.
+        Manager for investigations, experiments and scans.
 
-        An important task of the Manager driver is to request and collect metadata
-        *concurrently* from all other drivers. This is accomplished by creating
-        clients to each driver. These clients are instantiated (and re-instantiated)
-        on a separate thread running `self.client_loop`. For each client, the
-        method `fetch_meta` is started on a separate thread as soon as metadata collection
-        is requested. All this is done to ensure that metadata is obtained
-        as quickly as possible after it has been requested.
+        Args:
+            data_path (str): path to data directory
         """
         super().__init__()
+
+        self.data_path = data_path
 
         # Set initial parameters
         self._running = False
@@ -95,9 +73,6 @@ class Manager(DriverBase):
                           'experiment': lambda: self.experiment,
                           'last_scan': lambda: self._scan_number or None}
 
-        self.requests = {}      # Dictionary to accumulate requests in case many are made before returning
-        self.stop_flag = threading.Event()
-        self.clients = {}
         self.scan_info = {}
         self.last_scan_info = self.config['last_scan_info']
 
@@ -105,146 +80,6 @@ class Manager(DriverBase):
         global _client
         _client.clear()
         _client.append(self)
-
-        # self also instead of "client to self"
-        self.clients['manager'] = self
-
-        # Start client monitoring loop
-        self.clients_loop_future = Future(self.clients_loop)
-
-    def clients_loop(self):
-        """
-        A loop running on a thread monitoring the health of the driver connections
-        """
-        while True:
-            # Stop if asked
-            if self.stop_flag.is_set():
-                break
-
-            # Loop through all registered driver classes
-            for name in _driver_classes.keys():
-                if name.lower() == self.name.lower():
-                    continue
-                # If client does not exist
-                if name not in self.clients:
-                    # Attempt client instantiation
-                    with logging_muted():
-                        client = client_or_None(name, admin=False, client_name='manager_loop')
-                    if client:
-                        # Successful client connection
-                        self.logger.info(f'Client "{name}" is connected')
-
-                        # Store client
-                        self.clients[name] = client
-                else:
-                    try:
-                        cl = self.clients[name]
-                        cl.conn.ping()                        
-                    except (EOFError, TimeoutError) as error:
-                        # Client is dead for some reason. We clean this up and restart it
-                        self.logger.warning(f'Closing client to {name} because of failed ping: {repr(error)}')
-                        cl = self.clients.pop(name)
-                        try:
-                            cl.disconnect()
-                        except:
-                            pass
-            # Wait a bit before retrying
-            if self.stop_flag.wait(self.CLIENT_LOOP_INTERVAL):
-                break
-        self.logger.info('Exiting client connection loop.')
-
-    def fetch_meta(self, name):
-        """
-        Method run on a short-lived thread just the time to fetch metadata.
-        """
-        client = self.clients.get(name)
-        if client is None:
-            self.logger.warning(f'Client {name} not present.')
-            return None
-        t0 = time.time()
-        meta = client.get_meta()
-        dt = time.time() - t0
-        self.logger.debug(f'{name} : metadata collection completed in {dt * 1000:.3g} ms')
-        return {'meta':meta, 'time': dt}
-
-    @proxycall()
-    def request_meta(self, request_ID=None, exclude_list=[]):
-        """
-        Request metadata from all connected clients.
-
-        This method returns immediately. The metadata itself will be obtained when calling return_meta.
-
-        Args:
-            request_ID: a (hopefully unique) ID to tag and store the request until self.return_meta is called. It can be None.
-            exclude_list: a list of clients to exclude for the metadata requests.
-        Returns:
-            None
-        """
-        # Check for duplicate
-        duplicate = self.requests.get(request_ID, None)
-        if duplicate is not None:
-            self.logger.warning(f'Requests ID {request_ID} has not been claimed and will be overwritten.')
-
-        # Fetch metadata on separate threads
-        self.requests[request_ID] = {name:Future(self.fetch_meta, (name,)) for name in self.clients.keys() if name not in exclude_list}
-        return
-
-    @proxycall()
-    def return_meta(self, request_ID=None):
-        """
-        Return the metadata that has been accumulated since the last call to request_meta.
-
-        Args:
-            request_ID: The ID of the request made.
-
-        Returns:
-            A dictionary with all metadata.
-        """
-        if request_ID not in self.requests:
-            self.logger.error(f'Unknown request ID {request_ID}!')
-
-        # Pop the request
-        request = self.requests.pop(request_ID, {})
-        if not request:
-            self.logger.warning(f'Empty request: {request_ID}!')
-
-        meta = {}
-        times = {}
-        for name, future in request.items():
-            if not future.done():
-                self.logger.warning(f'{name}: metadata collection not completed in time.')
-            else:
-                result = future.result()
-                if result is not None:
-                    meta[name] = result['meta']
-                    times[name] = result['time']
-
-        return meta
-
-    @proxycall(admin=True)
-    def killall(self):
-        """
-        Kill all servers - except self!
-        """
-        while self.clients:
-            name, c = self.clients.popitem()
-            if name == 'manager':
-                # We don't kill ourselves
-                continue
-            c.ask_admin(True, True)
-            c.kill_server()
-            del c
-            self.logger.info(f'{name} killed.')
-
-    def shutdown(self):
-        """
-        Clean up
-        """
-        self.stop_flag.set()
-        m =  getManager()
-        if m:
-            del m
-        self.clients_loop_future.join()
 
     @proxycall()
     def start_scan(self, label=None):
@@ -280,7 +115,7 @@ class Manager(DriverBase):
         self.counter = 0
 
         # Create path (ok even if on control host)
-        os.makedirs(os.path.join(get_config()['data_path'], self.path, scan_name), exist_ok=True)
+        os.makedirs(os.path.join(self.data_path, self.path, scan_name), exist_ok=True)
 
         scan_info = {'scan_number': self._scan_number,
                 'scan_name': scan_name,
@@ -317,13 +152,12 @@ class Manager(DriverBase):
     @proxycall()
     def status(self):
         """
-        Summary of current configuration as a string
+        Summary of current configuration
         """
-        s = f' * Investigation: {self.investigation}\n'
-        s += f' * Experiment: {self.experiment}\n'
         ns = self.next_scan()
-        s += f' * Last scan number: {"[none]" if (ns is None or ns==0) else ns-1}'
-        return s
+        return {'investigation': self.investigation,
+                'experiment': self.experiment,
+                'last_scan': None if (ns is None or ns==0) else ns-1}
 
     @proxycall()
     def scan_status(self):
@@ -339,37 +173,6 @@ class Manager(DriverBase):
             out.update(self.last_scan_info)
 
         return out
-
-    @proxycall()
-    def get_stats(self):
-        """
-        Compute and return communication statistics for currently connected clients.
-        """
-        stats = {}
-        for name, c in self.clients.items():
-            try:
-                raw_stats = c.stats
-            except AttributeError:
-                # c could be self
-                continue
-            N = raw_stats['reply_number']
-            if N == 0:
-                # No stats
-                stats[name] = {'avg': None,
-                            'var': None,
-                            'min': None,
-                            'max': None,
-                            'N': 0}
-                continue
-            avg = raw_stats['total_reply_time']/N
-            var = raw_stats['total_reply_time2']/N - avg**2
-            client_stats = {'avg': avg,
-                            'var': var,
-                            'min': raw_stats['min_reply_time'],
-                            'max': raw_stats['max_reply_time'],
-                            'N': N}
-            stats[name] = client_stats
-        return stats
 
     @proxycall()
     def next_prefix(self):
@@ -396,7 +199,7 @@ class Manager(DriverBase):
         experiment path.
         """
         try:
-            exp_path = os.path.join(get_config()['data_path'], self.path)
+            exp_path = os.path.join(self.data_path, self.path)
         except RuntimeError as e:
             return None
         scan_numbers = [int(f.name[:6]) for f in os.scandir(exp_path) if f.is_dir()]
@@ -407,7 +210,7 @@ class Manager(DriverBase):
         If the current investigation / experiment values are set, check if path exists.
         """
         try:
-            full_path = os.path.join(get_config()['data_path'], self.path)
+            full_path = os.path.join(self.data_path, self.path)
             if os.path.exists(full_path):
                 self.logger.info(f'Path {full_path} selected (exists).')
             else:

--- a/lclib/manager.py
+++ b/lclib/manager.py
@@ -39,13 +39,17 @@ class ManagerBase(DriverBase):
     # Allowed characters for experiment and investigation names
     _VALID_CHAR = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-:'
 
+    # Will be replaced by subclass
+    DEFAULT_DATA_PATH = None
+
     DEFAULT_CONFIG = DriverBase.DEFAULT_CONFIG.copy()
     DEFAULT_CONFIG.update(
-                      {'experiment':None,
+                      {'data_path':None,
+                       'experiment':None,
                        'investigation':None,
-                       'last_scan_info': {}})
+                       'last_scan_info': {}},)
 
-    def __init__(self, data_path):
+    def __init__(self, data_path=None):
         """
         Manager for investigations, experiments and scans.
 
@@ -54,7 +58,10 @@ class ManagerBase(DriverBase):
         """
         super().__init__()
 
-        self.data_path = data_path
+        if data_path is None:
+            self.config['data_path'] = self.DEFAULT_DATA_PATH
+        else:
+            self.config['data_path'] = data_path
 
         # Set initial parameters
         self._running = False
@@ -115,7 +122,7 @@ class ManagerBase(DriverBase):
         self.counter = 0
 
         # Create path (ok even if on control host)
-        os.makedirs(os.path.join(self.data_path, self.path, scan_name), exist_ok=True)
+        os.makedirs(os.path.join(self.config['data_path'], self.path, scan_name), exist_ok=True)
 
         scan_info = {'scan_number': self._scan_number,
                 'scan_name': scan_name,
@@ -199,7 +206,7 @@ class ManagerBase(DriverBase):
         experiment path.
         """
         try:
-            exp_path = os.path.join(self.data_path, self.path)
+            exp_path = os.path.join(self.config['data_path'], self.path)
         except RuntimeError as e:
             return None
         scan_numbers = [int(f.name[:6]) for f in os.scandir(exp_path) if f.is_dir()]
@@ -210,7 +217,7 @@ class ManagerBase(DriverBase):
         If the current investigation / experiment values are set, check if path exists.
         """
         try:
-            full_path = os.path.join(self.data_path, self.path)
+            full_path = os.path.join(self.config['data_path'], self.path)
             if os.path.exists(full_path):
                 self.logger.info(f'Path {full_path} selected (exists).')
             else:

--- a/lclib/monitor.py
+++ b/lclib/monitor.py
@@ -1,0 +1,514 @@
+"""
+Management of experiment data, labeling, metadata, etc.
+
+The structure is inspired from Elettra's storage structure
+ - Investigation : highest category (e.g. speckle_long_branch)
+ - Experiment : Typically an experiment run (over days, possibly in multiple parts)
+ - Scan : (instead of Elettra's "dataset") a numbered (and possibly labeled) dataset
+
+This file is part of lab-control-lib
+(c) 2023-2024 Pierre Thibault (pthibault@units.it)
+"""
+import os
+from datetime import datetime
+import time
+import threading
+
+from . import (get_config,
+               MANAGER_ADDRESS,
+               _driver_classes,
+               client_or_None,
+               register_driver,
+               proxycall,
+               proxydevice)
+from .util import Future, now
+from .base import DriverBase
+from .logs import logging_muted
+
+logtags = {'type': 'manager',
+           'branch': 'both'
+           }
+
+_client = []
+
+
+def getManager():
+    """
+    A convenience function to return the current client (or a new one) for the Manager daemon.
+    """
+    if _client and _client[0]:
+        return _client[0]
+    d = client_or_None('manager', admin=False, client_name=f'client-{get_config()["this_host"]}')
+    _client.clear()
+    _client.append(d)
+    return d
+
+
+@register_driver
+@proxydevice(address=MANAGER_ADDRESS)
+class Manager(DriverBase):
+    """
+    Management of experiment structures and metadata.
+    """
+
+    # Allowed characters for experiment and investigation names
+    _VALID_CHAR = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-:'
+
+    # Interval at which attempts are made at connecting clients
+    CLIENT_LOOP_INTERVAL = 20.
+
+    DEFAULT_CONFIG = DriverBase.DEFAULT_CONFIG.copy()
+    DEFAULT_CONFIG.update(
+                      {'experiment':None,
+                       'investigation':None,
+                       'meta_to_save':{},
+                       'last_scan_info': {}})
+
+    def __init__(self):
+        """
+        Metadata manager for investigations, experiments and scans.
+
+        An important task of the Manager driver is to request and collect metadata
+        *concurrently* from all other drivers. This is accomplished by creating
+        clients to each driver. These clients are instantiated (and re-instantiated)
+        on a separate thread running `self.client_loop`. For each client, the
+        method `fetch_meta` is started on a separate thread as soon as metadata collection
+        is requested. All this is done to ensure that metadata is obtained
+        as quickly as possible after it has been requested.
+        """
+        super().__init__()
+
+        # Set initial parameters
+        self._running = False
+        self._scan_name = None
+        self._label = None
+        self._base_file_name = None
+        self._next_scan = None
+
+        try:
+            self._scan_number = self.next_scan()
+        except Exception as e:
+            self.logger.warning('Could not find first available scan number (have experiment and investigation been set?)')
+        self.counter = 0
+
+        self.metacalls = {'investigation': lambda: self.investigation,
+                          'experiment': lambda: self.experiment,
+                          'last_scan': lambda: self._scan_number or None}
+
+        self.requests = {}      # Dictionary to accumulate requests in case many are made before returning
+        self.stop_flag = threading.Event()
+        self.clients = {}
+        self.scan_info = {}
+        self.last_scan_info = self.config['last_scan_info']
+
+        # HACK (kind of): On the process where this class is instantiated, getManager must return this instance, not a client.
+        global _client
+        _client.clear()
+        _client.append(self)
+
+        # self also instead of "client to self"
+        self.clients['manager'] = self
+
+        # Start client monitoring loop
+        self.clients_loop_future = Future(self.clients_loop)
+
+    def clients_loop(self):
+        """
+        A loop running on a thread monitoring the health of the driver connections
+        """
+        while True:
+            # Stop if asked
+            if self.stop_flag.is_set():
+                break
+
+            # Loop through all registered driver classes
+            for name in _driver_classes.keys():
+                if name.lower() == self.name.lower():
+                    continue
+                # If client does not exist
+                if name not in self.clients:
+                    # Attempt client instantiation
+                    with logging_muted():
+                        client = client_or_None(name, admin=False, client_name='manager_loop')
+                    if client:
+                        # Successful client connection
+                        self.logger.info(f'Client "{name}" is connected')
+
+                        # Store client
+                        self.clients[name] = client
+                else:
+                    try:
+                        cl = self.clients[name]
+                        cl.conn.ping()                        
+                    except (EOFError, TimeoutError) as error:
+                        # Client is dead for some reason. We clean this up and restart it
+                        self.logger.warning(f'Closing client to {name} because of failed ping: {repr(error)}')
+                        cl = self.clients.pop(name)
+                        try:
+                            cl.disconnect()
+                        except:
+                            pass
+            # Wait a bit before retrying
+            if self.stop_flag.wait(self.CLIENT_LOOP_INTERVAL):
+                break
+        self.logger.info('Exiting client connection loop.')
+
+    def fetch_meta(self, name):
+        """
+        Method run on a short-lived thread just the time to fetch metadata.
+        """
+        client = self.clients.get(name)
+        if client is None:
+            self.logger.warning(f'Client {name} not present.')
+            return None
+        t0 = time.time()
+        meta = client.get_meta()
+        dt = time.time() - t0
+        self.logger.debug(f'{name} : metadata collection completed in {dt * 1000:.3g} ms')
+        return {'meta':meta, 'time': dt}
+
+    @proxycall()
+    def request_meta(self, request_ID=None, exclude_list=[]):
+        """
+        Request metadata from all connected clients.
+
+        This method returns immediately. The metadata itself will be obtained when calling return_meta.
+
+        Args:
+            request_ID: a (hopefully unique) ID to tag and store the request until self.return_meta is called. It can be None.
+            exclude_list: a list of clients to exclude for the metadata requests.
+        Returns:
+            None
+        """
+        # Check for duplicate
+        duplicate = self.requests.get(request_ID, None)
+        if duplicate is not None:
+            self.logger.warning(f'Requests ID {request_ID} has not been claimed and will be overwritten.')
+
+        # Fetch metadata on separate threads
+        self.requests[request_ID] = {name:Future(self.fetch_meta, (name,)) for name in self.clients.keys() if name not in exclude_list}
+        return
+
+    @proxycall()
+    def return_meta(self, request_ID=None):
+        """
+        Return the metadata that has been accumulated since the last call to request_meta.
+
+        Args:
+            request_ID: The ID of the request made.
+
+        Returns:
+            A dictionary with all metadata.
+        """
+        if request_ID not in self.requests:
+            self.logger.error(f'Unknown request ID {request_ID}!')
+
+        # Pop the request
+        request = self.requests.pop(request_ID, {})
+        if not request:
+            self.logger.warning(f'Empty request: {request_ID}!')
+
+        meta = {}
+        times = {}
+        for name, future in request.items():
+            if not future.done():
+                self.logger.warning(f'{name}: metadata collection not completed in time.')
+            else:
+                result = future.result()
+                if result is not None:
+                    meta[name] = result['meta']
+                    times[name] = result['time']
+
+        return meta
+
+    @proxycall(admin=True)
+    def killall(self):
+        """
+        Kill all servers - except self!
+        """
+        while self.clients:
+            name, c = self.clients.popitem()
+            if name == 'manager':
+                # We don't kill ourselves
+                continue
+            c.ask_admin(True, True)
+            c.kill_server()
+            del c
+            self.logger.info(f'{name} killed.')
+
+    def shutdown(self):
+        """
+        Clean up
+        """
+        self.stop_flag.set()
+        m =  getManager()
+        if m:
+            del m
+        self.clients_loop_future.join()
+
+    @proxycall()
+    def start_scan(self, label=None):
+        """
+        Start a new scan.
+        Args:
+            label: an optional label to be used for directory and file naming.
+
+        Returns:
+            `scan_info` dict with scan information.
+        """
+        if self._running:
+            raise RuntimeError(f'Scan {self.scan_name} already running')
+
+        # New scan start time
+        start_time = now()
+
+        # Get new scan number
+        self._scan_number = self.next_scan()
+
+        # Create scan name
+        today = datetime.now().strftime('%y-%m-%d')
+
+        scan_name = f'{self._scan_number:06d}_{today}'
+        if label is not None:
+            scan_name += f'_{label}'
+
+        self._scan_name = scan_name
+        self._base_file_name = scan_name + '_{0:06d}'
+
+        self._running = True
+        self._label = label
+        self.counter = 0
+
+        # Create path (ok even if on control host)
+        os.makedirs(os.path.join(get_config()['data_path'], self.path, scan_name), exist_ok=True)
+
+        scan_info = {'scan_number': self._scan_number,
+                'scan_name': scan_name,
+                'investigation': self.investigation,
+                'experiment': self.experiment,
+                'path': self.path,
+                'start_time': start_time}
+
+        # Store for status access
+        self.scan_info = scan_info
+
+        return scan_info
+
+    @proxycall()
+    def end_scan(self):
+        """
+        Finalize the scan
+        """
+        if not self._running:
+            raise RuntimeError(f'No scan currently running')
+
+        self._running = False
+
+        self.last_scan_info = self.scan_info
+        self.last_scan_info['end_time'] = now()
+        self.last_scan_info['counter'] = self.counter
+
+        self.config['last_scan_info'] = self.last_scan_info
+
+        self.scan_info = {}
+
+        return self.last_scan_info
+
+    @proxycall()
+    def status(self):
+        """
+        Summary of current configuration as a string
+        """
+        s = f' * Investigation: {self.investigation}\n'
+        s += f' * Experiment: {self.experiment}\n'
+        ns = self.next_scan()
+        s += f' * Last scan number: {"[none]" if (ns is None or ns==0) else ns-1}'
+        return s
+
+    @proxycall()
+    def scan_status(self):
+        """
+        Return information about current scan if running, otherwise about the last scan
+        """
+        out = {}
+        if self._running:
+            out.update(self.scan_info)
+            out['counter'] = self.counter
+            out['now'] = now()
+        else:
+            out.update(self.last_scan_info)
+
+        return out
+
+    @proxycall()
+    def get_stats(self):
+        """
+        Compute and return communication statistics for currently connected clients.
+        """
+        stats = {}
+        for name, c in self.clients.items():
+            try:
+                raw_stats = c.stats
+            except AttributeError:
+                # c could be self
+                continue
+            N = raw_stats['reply_number']
+            if N == 0:
+                # No stats
+                stats[name] = {'avg': None,
+                            'var': None,
+                            'min': None,
+                            'max': None,
+                            'N': 0}
+                continue
+            avg = raw_stats['total_reply_time']/N
+            var = raw_stats['total_reply_time2']/N - avg**2
+            client_stats = {'avg': avg,
+                            'var': var,
+                            'min': raw_stats['min_reply_time'],
+                            'max': raw_stats['max_reply_time'],
+                            'N': N}
+            stats[name] = client_stats
+        return stats
+
+    @proxycall()
+    def next_prefix(self):
+        """
+        Return full prefix identifier and increment counter.
+        """
+        if not self._running:
+            raise RuntimeError(f'No scan currently running')
+        prefix = self._base_file_name.format(self.counter)
+        self.counter += 1
+        return prefix
+
+    @proxycall()
+    def get_counter(self):
+        """
+        Return current counter value (unlike next_prefix, does not increment the counter)
+        """
+        return self.counter
+
+    @proxycall()
+    def next_scan(self):
+        """
+        Return the next available scan number based on the analysis of the
+        experiment path.
+        """
+        try:
+            exp_path = os.path.join(get_config()['data_path'], self.path)
+        except RuntimeError as e:
+            return None
+        scan_numbers = [int(f.name[:6]) for f in os.scandir(exp_path) if f.is_dir()]
+        return max(scan_numbers, default=-1) + 1
+
+    def _check_path(self):
+        """
+        If the current investigation / experiment values are set, check if path exists.
+        """
+        try:
+            full_path = os.path.join(get_config()['data_path'], self.path)
+            if os.path.exists(full_path):
+                self.logger.info(f'Path {full_path} selected (exists).')
+            else:
+                os.makedirs(full_path, exist_ok=True)
+                self.logger.info(f'Created path {full_path}.')
+        except RuntimeError as e:
+            self.logger.warning(str(e))
+
+    def _valid_name(self, s):
+        """
+        Confirm that the given string can be used as part of a path
+        """
+        return all(c in self._VALID_CHAR for c in s)
+
+    @proxycall()
+    @property
+    def scan_name(self):
+        """
+        Return the full scan name - none if no scan is running.
+        """
+        if not self._running:
+            return None
+        return self._scan_name
+
+    @proxycall()
+    @property
+    def investigation(self):
+        """
+        The current investigation name.
+
+        *** Setting the investigation makes experiment None. ***
+        """
+        return self.config.get('investigation')
+
+    @investigation.setter
+    def investigation(self, v):
+        if v is None:
+            raise RuntimeError(f'Investigation should not be set to "None"')
+        if self._running:
+            raise RuntimeError(f'Investigation cannot be modified while a scan is running.')
+        if not self._valid_name(v):
+            raise RuntimeError(f'Invalid investigation name: {v}')
+        self.config['investigation'] = v
+        self.config['experiment'] = None
+
+    @proxycall()
+    @property
+    def experiment(self):
+        """
+        The current experiment name.
+        """
+        return self.config['experiment']
+
+    @experiment.setter
+    def experiment(self, v):
+        if v is None:
+            raise RuntimeError(f'Experiment should not be set to "None"')
+        if self._running:
+            raise RuntimeError(f'Experiment cannot be modified while a scan is running.')
+        if self.investigation is None:
+            raise RuntimeError(f'Investigation is not set.')
+        if not self._valid_name(v):
+            raise RuntimeError(f'Invalid experiment name: {v}')
+        self.config['experiment'] = v
+        self._check_path()
+
+    @proxycall()
+    @property
+    def scanning(self):
+        """
+        True if a scan is currently running
+        """
+        return self._running
+
+    @property
+    def path(self):
+        """
+        Return experiment path
+        """
+        experiment = self.experiment
+        investigation = self.investigation
+        if (experiment is None) or (investigation is None):
+            raise RuntimeError('Experiment or Investigation not set.')
+        return os.path.join(investigation, experiment)
+
+    @proxycall()
+    @property
+    def scan_path(self):
+        """
+        Return scan path - None if no scan is running.
+        """
+        if not self._running:
+            return None
+        return os.path.join(self.path, self.scan_name)
+
+    @proxycall()
+    @property
+    def scan_number(self):
+        """
+        Return scan name - None if no scan is running.
+        """
+        if not self._running:
+            return None
+        return self._scan_number

--- a/lclib/monitor.py
+++ b/lclib/monitor.py
@@ -186,6 +186,11 @@ class MonitorBase(DriverBase):
             if name == self.name:
                 # We don't kill ourselves
                 continue
+            if not c.connected:
+                # Not connected
+                self.logger.info(f'{name} not connected: skipping')
+                continue
+            self.logger.debug(f'Killing {name}')
             c.ask_admin(True, True)
             c.kill_server()
             del c

--- a/lclib/monitor.py
+++ b/lclib/monitor.py
@@ -82,6 +82,9 @@ class MonitorBase(DriverBase):
 
         # Make clients more quiet
         for name, c in self.clients.items():
+            if c is None:
+                self.logger.error(f'Client {name} is None')
+                continue
             c.logger.setLevel(logging.WARNING)
 
         # Add self also instead of "client to self"

--- a/lclib/monitor.py
+++ b/lclib/monitor.py
@@ -1,165 +1,93 @@
 """
-Management of experiment data, labeling, metadata, etc.
-
-The structure is inspired from Elettra's storage structure
- - Investigation : highest category (e.g. speckle_long_branch)
- - Experiment : Typically an experiment run (over days, possibly in multiple parts)
- - Scan : (instead of Elettra's "dataset") a numbered (and possibly labeled) dataset
+Management of metadata.
 
 This file is part of lab-control-lib
 (c) 2023-2024 Pierre Thibault (pthibault@units.it)
 """
-import os
-from datetime import datetime
+import logging
 import time
 import threading
 
 from . import (get_config,
-               MANAGER_ADDRESS,
+               MONITOR_ADDRESS,
                _driver_classes,
                client_or_None,
                register_driver,
                proxycall,
                proxydevice)
-from .util import Future, now
+from .util import Future
 from .base import DriverBase
-from .logs import logging_muted
 
-logtags = {'type': 'manager',
-           'branch': 'both'
-           }
-
+# Used to store existing client
 _client = []
 
 
-def getManager():
+def getMonitor():
     """
     A convenience function to return the current client (or a new one) for the Manager daemon.
     """
     if _client and _client[0]:
         return _client[0]
-    d = client_or_None('manager', admin=False, client_name=f'client-{get_config()["this_host"]}')
+    d = client_or_None('monitor', admin=False, client_name=f'client-{get_config()["this_host"]}')
     _client.clear()
     _client.append(d)
     return d
 
 
 @register_driver
-@proxydevice(address=MANAGER_ADDRESS)
-class Manager(DriverBase):
+@proxydevice(address=MONITOR_ADDRESS)
+class Monitor(DriverBase):
     """
-    Management of experiment structures and metadata.
+    Device monitoring and metadata collection.
     """
-
-    # Allowed characters for experiment and investigation names
-    _VALID_CHAR = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-:'
-
-    # Interval at which attempts are made at connecting clients
-    CLIENT_LOOP_INTERVAL = 20.
 
     DEFAULT_CONFIG = DriverBase.DEFAULT_CONFIG.copy()
-    DEFAULT_CONFIG.update(
-                      {'experiment':None,
-                       'investigation':None,
-                       'meta_to_save':{},
-                       'last_scan_info': {}})
 
     def __init__(self):
         """
-        Metadata manager for investigations, experiments and scans.
+        Device supervision and metadata collection.
 
-        An important task of the Manager driver is to request and collect metadata
-        *concurrently* from all other drivers. This is accomplished by creating
-        clients to each driver. These clients are instantiated (and re-instantiated)
-        on a separate thread running `self.client_loop`. For each client, the
-        method `fetch_meta` is started on a separate thread as soon as metadata collection
-        is requested. All this is done to ensure that metadata is obtained
-        as quickly as possible after it has been requested.
+        The Monitor driver keeps clients connected to all available devices, and attempts
+        periodically to connect to those that are known but unavailable.
+        The Monitor can request and collect metadata *concurrently* from all available drivers.
+        See `request_meta` and `return_meta` for an explanation of the metadata collection
+        mechanism.
+
+        The Monitor also has the capability to kill drivers.
+
+        TODO: implement a mechanism to spawn drivers (tricky because multiplatform)
         """
         super().__init__()
-
-        # Set initial parameters
-        self._running = False
-        self._scan_name = None
-        self._label = None
-        self._base_file_name = None
-        self._next_scan = None
-
-        try:
-            self._scan_number = self.next_scan()
-        except Exception as e:
-            self.logger.warning('Could not find first available scan number (have experiment and investigation been set?)')
-        self.counter = 0
-
-        self.metacalls = {'investigation': lambda: self.investigation,
-                          'experiment': lambda: self.experiment,
-                          'last_scan': lambda: self._scan_number or None}
 
         self.requests = {}      # Dictionary to accumulate requests in case many are made before returning
         self.stop_flag = threading.Event()
         self.clients = {}
-        self.scan_info = {}
-        self.last_scan_info = self.config['last_scan_info']
 
-        # HACK (kind of): On the process where this class is instantiated, getManager must return this instance, not a client.
+        # HACK (kind of): On the process where this class is instantiated, getMonitor must return this instance, not a client.
         global _client
         _client.clear()
         _client.append(self)
 
-        # self also instead of "client to self"
-        self.clients['manager'] = self
+        # Create all clients (except to self)
+        self.clients = {name:client_or_None(name, admin=False, client_name='monitor', keep_trying=True) for name in _driver_classes.keys() if name != self.name}
 
-        # Start client monitoring loop
-        self.clients_loop_future = Future(self.clients_loop)
+        # Make clients more quiet
+        for name, c in self.clients.items():
+            c.logger.setLevel(logging.WARNING)
 
-    def clients_loop(self):
-        """
-        A loop running on a thread monitoring the health of the driver connections
-        """
-        while True:
-            # Stop if asked
-            if self.stop_flag.is_set():
-                break
+        # Add self also instead of "client to self"
+        self.clients[self.name] = self
 
-            # Loop through all registered driver classes
-            for name in _driver_classes.keys():
-                if name.lower() == self.name.lower():
-                    continue
-                # If client does not exist
-                if name not in self.clients:
-                    # Attempt client instantiation
-                    with logging_muted():
-                        client = client_or_None(name, admin=False, client_name='manager_loop')
-                    if client:
-                        # Successful client connection
-                        self.logger.info(f'Client "{name}" is connected')
-
-                        # Store client
-                        self.clients[name] = client
-                else:
-                    try:
-                        cl = self.clients[name]
-                        cl.conn.ping()                        
-                    except (EOFError, TimeoutError) as error:
-                        # Client is dead for some reason. We clean this up and restart it
-                        self.logger.warning(f'Closing client to {name} because of failed ping: {repr(error)}')
-                        cl = self.clients.pop(name)
-                        try:
-                            cl.disconnect()
-                        except:
-                            pass
-            # Wait a bit before retrying
-            if self.stop_flag.wait(self.CLIENT_LOOP_INTERVAL):
-                break
-        self.logger.info('Exiting client connection loop.')
+        # This is used for stats
+        self.connected = True
 
     def fetch_meta(self, name):
         """
         Method run on a short-lived thread just the time to fetch metadata.
         """
         client = self.clients.get(name)
-        if client is None:
-            self.logger.warning(f'Client {name} not present.')
+        if client is None or not client.connected:
+            self.logger.warning(f'Client {name}: no metadata available.')
             return None
         t0 = time.time()
         meta = client.get_meta()
@@ -168,14 +96,16 @@ class Manager(DriverBase):
         return {'meta':meta, 'time': dt}
 
     @proxycall()
-    def request_meta(self, request_ID=None, exclude_list=[]):
+    def request_meta(self, request_ID=None, include_list=None, exclude_list=None):
         """
         Request metadata from all connected clients.
 
-        This method returns immediately. The metadata itself will be obtained when calling return_meta.
+        This method starts one thread (`Future` per client) and returns immediately. The metadata itself will be
+        obtained when calling return_meta.
 
         Args:
             request_ID: a (hopefully unique) ID to tag and store the request until self.return_meta is called. It can be None.
+            include_list: ignored if None. Otherwise, request metadata only of the components in include_list.
             exclude_list: a list of clients to exclude for the metadata requests.
         Returns:
             None
@@ -185,8 +115,12 @@ class Manager(DriverBase):
         if duplicate is not None:
             self.logger.warning(f'Requests ID {request_ID} has not been claimed and will be overwritten.')
 
+        exclude_list = exclude_list or []
+        if include_list is None:
+            include_list = [name for name in self.clients.keys() if name not in exclude_list]
+
         # Fetch metadata on separate threads
-        self.requests[request_ID] = {name:Future(self.fetch_meta, (name,)) for name in self.clients.keys() if name not in exclude_list}
+        self.requests[request_ID] = {name:Future(self.fetch_meta, (name,)) for name in include_list}
         return
 
     @proxycall()
@@ -208,6 +142,7 @@ class Manager(DriverBase):
         if not request:
             self.logger.warning(f'Empty request: {request_ID}!')
 
+        # Grab all available metadata
         meta = {}
         times = {}
         for name, future in request.items():
@@ -216,19 +151,30 @@ class Manager(DriverBase):
             else:
                 result = future.result()
                 if result is not None:
+                    # TODO: some diagnostics using the times dictionary
                     meta[name] = result['meta']
                     times[name] = result['time']
 
         return meta
 
     @proxycall(admin=True)
-    def killall(self):
+    def killall(self, components=None):
         """
         Kill all servers - except self!
+
+        Args:
+            components: if not None, kill only listed components. Default is None - kill all.
         """
-        while self.clients:
-            name, c = self.clients.popitem()
-            if name == 'manager':
+        if components is None:
+            components = self.clients.keys()
+
+        for name in components:
+            try:
+                c = self.clients.pop(name)
+            except KeyError:
+                self.logger.error(f'Unknown component {name}!')
+                continue
+            if name == self.name:
                 # We don't kill ourselves
                 continue
             c.ask_admin(True, True)
@@ -241,104 +187,20 @@ class Manager(DriverBase):
         Clean up
         """
         self.stop_flag.set()
-        m =  getManager()
+        m =  getMonitor()
         if m:
             del m
-        self.clients_loop_future.join()
-
-    @proxycall()
-    def start_scan(self, label=None):
-        """
-        Start a new scan.
-        Args:
-            label: an optional label to be used for directory and file naming.
-
-        Returns:
-            `scan_info` dict with scan information.
-        """
-        if self._running:
-            raise RuntimeError(f'Scan {self.scan_name} already running')
-
-        # New scan start time
-        start_time = now()
-
-        # Get new scan number
-        self._scan_number = self.next_scan()
-
-        # Create scan name
-        today = datetime.now().strftime('%y-%m-%d')
-
-        scan_name = f'{self._scan_number:06d}_{today}'
-        if label is not None:
-            scan_name += f'_{label}'
-
-        self._scan_name = scan_name
-        self._base_file_name = scan_name + '_{0:06d}'
-
-        self._running = True
-        self._label = label
-        self.counter = 0
-
-        # Create path (ok even if on control host)
-        os.makedirs(os.path.join(get_config()['data_path'], self.path, scan_name), exist_ok=True)
-
-        scan_info = {'scan_number': self._scan_number,
-                'scan_name': scan_name,
-                'investigation': self.investigation,
-                'experiment': self.experiment,
-                'path': self.path,
-                'start_time': start_time}
-
-        # Store for status access
-        self.scan_info = scan_info
-
-        return scan_info
-
-    @proxycall()
-    def end_scan(self):
-        """
-        Finalize the scan
-        """
-        if not self._running:
-            raise RuntimeError(f'No scan currently running')
-
-        self._running = False
-
-        self.last_scan_info = self.scan_info
-        self.last_scan_info['end_time'] = now()
-        self.last_scan_info['counter'] = self.counter
-
-        self.config['last_scan_info'] = self.last_scan_info
-
-        self.scan_info = {}
-
-        return self.last_scan_info
 
     @proxycall()
     def status(self):
         """
-        Summary of current configuration as a string
+        Current status of the system.
         """
-        s = f' * Investigation: {self.investigation}\n'
-        s += f' * Experiment: {self.experiment}\n'
-        ns = self.next_scan()
-        s += f' * Last scan number: {"[none]" if (ns is None or ns==0) else ns-1}'
-        return s
-
-    @proxycall()
-    def scan_status(self):
-        """
-        Return information about current scan if running, otherwise about the last scan
-        """
-        out = {}
-        if self._running:
-            out.update(self.scan_info)
-            out['counter'] = self.counter
-            out['now'] = now()
-        else:
-            out.update(self.last_scan_info)
-
-        return out
+        # Number of connected clients
+        Ntotal = len(self.clients)
+        Nconnected = len([c for n, c in self.clients.items() if c.connected])
+        stats = self.get_stats()
+        return {'clients': Ntotal, 'connected': Nconnected, 'stats': stats}
 
     @proxycall()
     def get_stats(self):
@@ -348,6 +210,8 @@ class Manager(DriverBase):
         stats = {}
         for name, c in self.clients.items():
             try:
+                if not c.connected:
+                    continue
                 raw_stats = c.stats
             except AttributeError:
                 # c could be self
@@ -370,145 +234,3 @@ class Manager(DriverBase):
                             'N': N}
             stats[name] = client_stats
         return stats
-
-    @proxycall()
-    def next_prefix(self):
-        """
-        Return full prefix identifier and increment counter.
-        """
-        if not self._running:
-            raise RuntimeError(f'No scan currently running')
-        prefix = self._base_file_name.format(self.counter)
-        self.counter += 1
-        return prefix
-
-    @proxycall()
-    def get_counter(self):
-        """
-        Return current counter value (unlike next_prefix, does not increment the counter)
-        """
-        return self.counter
-
-    @proxycall()
-    def next_scan(self):
-        """
-        Return the next available scan number based on the analysis of the
-        experiment path.
-        """
-        try:
-            exp_path = os.path.join(get_config()['data_path'], self.path)
-        except RuntimeError as e:
-            return None
-        scan_numbers = [int(f.name[:6]) for f in os.scandir(exp_path) if f.is_dir()]
-        return max(scan_numbers, default=-1) + 1
-
-    def _check_path(self):
-        """
-        If the current investigation / experiment values are set, check if path exists.
-        """
-        try:
-            full_path = os.path.join(get_config()['data_path'], self.path)
-            if os.path.exists(full_path):
-                self.logger.info(f'Path {full_path} selected (exists).')
-            else:
-                os.makedirs(full_path, exist_ok=True)
-                self.logger.info(f'Created path {full_path}.')
-        except RuntimeError as e:
-            self.logger.warning(str(e))
-
-    def _valid_name(self, s):
-        """
-        Confirm that the given string can be used as part of a path
-        """
-        return all(c in self._VALID_CHAR for c in s)
-
-    @proxycall()
-    @property
-    def scan_name(self):
-        """
-        Return the full scan name - none if no scan is running.
-        """
-        if not self._running:
-            return None
-        return self._scan_name
-
-    @proxycall()
-    @property
-    def investigation(self):
-        """
-        The current investigation name.
-
-        *** Setting the investigation makes experiment None. ***
-        """
-        return self.config.get('investigation')
-
-    @investigation.setter
-    def investigation(self, v):
-        if v is None:
-            raise RuntimeError(f'Investigation should not be set to "None"')
-        if self._running:
-            raise RuntimeError(f'Investigation cannot be modified while a scan is running.')
-        if not self._valid_name(v):
-            raise RuntimeError(f'Invalid investigation name: {v}')
-        self.config['investigation'] = v
-        self.config['experiment'] = None
-
-    @proxycall()
-    @property
-    def experiment(self):
-        """
-        The current experiment name.
-        """
-        return self.config['experiment']
-
-    @experiment.setter
-    def experiment(self, v):
-        if v is None:
-            raise RuntimeError(f'Experiment should not be set to "None"')
-        if self._running:
-            raise RuntimeError(f'Experiment cannot be modified while a scan is running.')
-        if self.investigation is None:
-            raise RuntimeError(f'Investigation is not set.')
-        if not self._valid_name(v):
-            raise RuntimeError(f'Invalid experiment name: {v}')
-        self.config['experiment'] = v
-        self._check_path()
-
-    @proxycall()
-    @property
-    def scanning(self):
-        """
-        True if a scan is currently running
-        """
-        return self._running
-
-    @property
-    def path(self):
-        """
-        Return experiment path
-        """
-        experiment = self.experiment
-        investigation = self.investigation
-        if (experiment is None) or (investigation is None):
-            raise RuntimeError('Experiment or Investigation not set.')
-        return os.path.join(investigation, experiment)
-
-    @proxycall()
-    @property
-    def scan_path(self):
-        """
-        Return scan path - None if no scan is running.
-        """
-        if not self._running:
-            return None
-        return os.path.join(self.path, self.scan_name)
-
-    @proxycall()
-    @property
-    def scan_number(self):
-        """
-        Return scan name - None if no scan is running.
-        """
-        if not self._running:
-            return None
-        return self._scan_number

--- a/lclib/monitor.py
+++ b/lclib/monitor.py
@@ -9,10 +9,8 @@ import time
 import threading
 
 from . import (get_config,
-               MONITOR_ADDRESS,
                _driver_classes,
                client_or_None,
-               register_driver,
                proxycall,
                proxydevice)
 from .util import Future
@@ -34,11 +32,22 @@ def getMonitor():
     return d
 
 
-@register_driver
-@proxydevice(address=MONITOR_ADDRESS)
-class Monitor(DriverBase):
+@proxydevice(address=None)
+class MonitorBase(DriverBase):
     """
     Device monitoring and metadata collection.
+
+    Any package has to subclass this class with
+    * the `register_driver` decorator, and
+    * the `proxydevice` decorator, with the appropriate address.
+
+    ::
+        @register_driver
+        @proxydevice(address=(IP, PORT))
+        class Monitor(MonitorBase):
+            pass
+
+    The Monitor subclass can be augmented with custom methods decorated with `proxycall`.
     """
 
     DEFAULT_CONFIG = DriverBase.DEFAULT_CONFIG.copy()

--- a/lclib/monitor.py
+++ b/lclib/monitor.py
@@ -175,7 +175,7 @@ class MonitorBase(DriverBase):
             components: if not None, kill only listed components. Default is None - kill all.
         """
         if components is None:
-            components = self.clients.keys()
+            components = list(self.clients.keys())
 
         for name in components:
             try:

--- a/lclib/ui/ui.py
+++ b/lclib/ui/ui.py
@@ -35,8 +35,8 @@ def init(yes=None):
         uitools.user_interactive = False
 
     # Experiment management
-    man = manager.getManager()
-    print(man.status())
+    man = client_or_None('manager')
+    print(" * Investigation: {investigation}\n * Experiment: {experiment}\n * Last Scan: {last_scan}".format(**man.status()))
     load_past_investigations()
 
     client_name = f'main-client-{get_config()["this_host"]}'


### PR DESCRIPTION
This PR introduces `Monitor`, a new "driver" (maybe we could call it a "service" instead). The functionality as a whole is unchanged, since what has been done is to split the responsibility of `Manager` in two. `Monitor` is the service that supervises all drivers through active clients, and collects metadata if needed. `Manager` is instead meant to manage experiments: deciding of scan numbers, labels, and paths for data storage.

The reason for this split is that it is now going to be able to have multiple `Manager` subclasses, representing different experimental configurations. For our lab, this will be necessary when both imaging branches become active and we require conducting two experiments simultaneously.  