### PR TITLE
Metadata throttling

### DIFF
--- a/lclib/__init__.py
+++ b/lclib/__init__.py
@@ -179,8 +179,7 @@ def init(lab_name,
     Args:
         lab_name: (str) The name of the laboratory
         host_ips: (dict) Dict of host names and IPs in  the laboratory LAN {hostname1: ip1, hostname2: ip2, ...}
-        data_path: Main path to save data (from control node)
-        manager_address: the address for the manager.
+        monitor_address: the address for the monitor object.
     """
     global config
     BANNER = '*{0:^120}*'
@@ -254,7 +253,7 @@ def init(lab_name,
     # Monitor address
     #
     if monitor_address is None:
-        # Get manager address from config file, or revert to default
+        # Get monitor address from config file, or revert to default
         monitor_address = config.get('monitor_address', (host_ips['control'], DEFAULT_MONITOR_PORT))
 
     #

--- a/lclib/camera.py
+++ b/lclib/camera.py
@@ -327,7 +327,7 @@ class CameraBase(DriverBase):
                 if not self.monitor.connected:
                     self.logger.error("Not connected to monitor! Cannot request metadata!")
                 else:
-                    self.monitor.request_meta(request_ID=once_request_ID, exclude_list=[self.name])
+                    self.monitor.request_meta(request_ID=once_request_ID, exclude_list=[self.name, self.config['experiment_manager']])
 
             filename = self.filename
             self.do_acquire.clear()
@@ -536,7 +536,7 @@ class CameraBase(DriverBase):
             metadata = {'manager': self.manager_meta}
             if (not self.bypass_metadata) and (request_ID is not None):
                 if self.monitor.connected:
-                    metadata = self.monitor.return_meta(request_ID)
+                    metadata.update(self.monitor.return_meta(request_ID))
 
             # Get metadata
             localmeta = self.localmeta.pop(request_ID, {})

--- a/lclib/camera.py
+++ b/lclib/camera.py
@@ -303,6 +303,9 @@ class CameraBase(DriverBase):
         rate = 1./self.exposure_time
         if rate > self.config['max_rate_metadata']:
             self.bypass_metadata = True
+            self.logger.info('Metadata collection will be bypassed because of too high frame rate.')
+
+        once_request_ID = f'{self.name}_once'
 
         self.logger.debug('Acquisition loop started')
         self.abort_flag.clear()
@@ -314,6 +317,15 @@ class CameraBase(DriverBase):
                     self.logger.debug('end_acquisition is True. Breaking out.')
                     break
                 continue
+
+            # Request metadata one time
+            if self.bypass_metadata:
+                # Request global metadata (exclude self, we do that locally instead)
+                if not self.monitor.connected:
+                    self.logger.error("Not connected to monitor! Cannot request metadata!")
+                else:
+                    self.monitor.request_meta(request_ID=once_request_ID, exclude_list=[self.name])
+
             filename = self.filename
             self.do_acquire.clear()
             self.logger.debug('Received acquisition request (do_acquire flag).')
@@ -330,8 +342,6 @@ class CameraBase(DriverBase):
                 # Execute actual exposures
                 self._trigger()
 
-                # Enqueue None to signal end-of-exposure
-                self.enqueue_frame(None, None)
             except:
                 self.logger.exception('Error in _trigger')
                 self.acquire_done.set()
@@ -348,6 +358,16 @@ class CameraBase(DriverBase):
             #    break
 
             self.logger.debug('Done calling the subclass trigger.')
+
+            # If metadata requests were bypassed, grab it now before closing
+            metadata = None
+            if self.bypass_metadata:
+                self.logger.debug('Fetching metadata at the end of the acquisition (bypassed during exposures)')
+                if self.monitor.connected:
+                    metadata = self.monitor.return_meta(once_request_ID)
+            # Signal end of exposure by passing a None frame.
+            # Non-None metadata will be managed by file_writer appropriately
+            self.enqueue_frame(None, metadata)
 
             # Flip flag immediately to allow snap to return.
             self.logger.debug('Setting acquire_done flag.')
@@ -403,6 +423,9 @@ class CameraBase(DriverBase):
         self.localmeta[ticket] = localmeta
         self._last_request_ID = ticket
 
+        # Increment metadata counter
+        self.metadata_counter += 1
+
     def frame_management_loop(self):
         """
         Running on a thread. Watches self.frame_queue and deals with the data as
@@ -425,6 +448,11 @@ class CameraBase(DriverBase):
             data, meta = item
 
             if data is None:
+                # Special case: no frame, but metadata present. This happens if metadata was requested at the start of
+                # an acquisition and other calls were bypassed because of too high frame rate. frame_writer knows how to
+                # deal with this.
+                if not self.rolling and (meta is not None):
+                    self.frame_writer.store(meta=meta, data=data)
                 self.logger.debug('Setting end-of-exposure flag')
                 self.end_of_exposure_flag.set()
                 continue
@@ -501,11 +529,10 @@ class CameraBase(DriverBase):
             if request_ID is None:
                 self.logger.error('In camera.enqueue_frame: last_request_ID should not be None')
 
+            metadata = {}
             if (not self.bypass_metadata) and (request_ID is not None):
                 if self.monitor.connected:
                     metadata = self.monitor.return_meta(request_ID)
-                else:
-                    metadata = {}
 
             # Get metadata
             localmeta = self.localmeta.pop(request_ID, {})

--- a/lclib/camera.py
+++ b/lclib/camera.py
@@ -88,11 +88,12 @@ class CameraBase(DriverBase):
 
     DEFAULT_BROADCAST_ADDRESS = DEFAULT_BROADCAST_ADDRESS  # Default port for frame broadcasting
     BASE_PATH = ""
-    PIXEL_SIZE = (0, 0)  # Pixel size in um
-    SHAPE = (0, 0)  # Native array dimensions (before binning)
-    DATATYPE = 'uint16'  # Expected datatype
-    DEFAULT_FPS = 5.
-    MAX_FPS = 5.
+    PIXEL_SIZE = (0, 0)     # Pixel size in um
+    SHAPE = (0, 0)          # Native array dimensions (before binning)
+    DATATYPE = 'uint16'     # Expected datatype
+    DEFAULT_FPS = 5.        # Default FPS (frame per seconds) for live view (roll) 
+    MAX_FPS = 5.            # Default maximum FPS for roll
+    MAX_RATE_METADATA = 10  # Default maximum FPS above which metadata collection will be bypassed
 
     LOCAL_DEFAULT_CONFIG = {'do_save': True,
                             'file_format': DEFAULT_FILE_FORMAT,
@@ -106,7 +107,9 @@ class CameraBase(DriverBase):
                             'operation_mode': None,
                             'exposure_time': 1.,
                             'exposure_number': 1,
-                            'accumulation_number': 1}
+                            'accumulation_number': 1,
+                            'experiment_manager': 'manager',
+                            'max_rate_metadata': 10}
 
     # python >3.9
     # DEFAULT_CONFIG = (DriverBase.DEFAULT_CONFIG | LOCAL_DEFAULT_CONFIG)
@@ -124,11 +127,12 @@ class CameraBase(DriverBase):
         else:
             self.broadcast_address = broadcast_address
 
-        # Clients to monitor and manager
+        # Connect to monitor
         self.monitor = client_or_None('monitor', keep_trying=True)
 
-        # TODO: in the future, we should be able to swap managers
-        self.manager = client_or_None('manager', keep_trying=True)
+        # Connect to manager
+        experiment_manager = self.config['experiment_manager']
+        self.set_manager(experiment_manager)
 
         self.store_future = None      # Will be replaced with a future when starting to store.
         self._stop_roll = False       # To interrupt rolling
@@ -156,8 +160,9 @@ class CameraBase(DriverBase):
         # Prepare metadata collection
         self.metadata = {}
         self.localmeta = {}
-        self.grab_metadata = threading.Event()
-        self.meta_future = Future(self.metadata_loop)
+        self.metadata_counter = 0
+        self.bypass_metadata = False
+        self._last_request_ID = None
 
         self.do_acquire = threading.Event()
         self.acquire_done = threading.Event()
@@ -291,6 +296,14 @@ class CameraBase(DriverBase):
 
         NOTE: This it started on a thread every time the camera is armed.
         """
+        # Check if the frame rate will be too high for metadata collection
+        if self.exposure_time == 0.:
+           self.logger.error('Acquisition loop cannot start with exposure time = 0!')
+           return
+        rate = 1./self.exposure_time
+        if rate > self.config['max_rate_metadata']:
+            self.bypass_metadata = True
+
         self.logger.debug('Acquisition loop started')
         self.abort_flag.clear()
         while True:
@@ -365,31 +378,30 @@ class CameraBase(DriverBase):
         # The loop is closed, we are done
         self.logger.debug('Acquisition loop completed')
 
-    def metadata_loop(self):
-        """
-        Running on a thread. Waiting for the "grab_metadata flag to be flipped, then
-        attach most recent metadata to self.metadata
-        """
-        time.sleep(.5)
-        self.logger.debug('Metadata loop started')
-        while True:
-            if not self.grab_metadata.wait(1):
-                if self.closing:
-                    return
-                continue
-            self.grab_metadata.clear()
-            self.logger.debug('Metadata collection requested (grab_metadata flag)')
+        # Reset metadata rate limit
+        self.bypass_metadata = False
 
+    def request_meta(self):
+        """
+        Request metadata.
+        """
+        self.logger.debug('Metadata collection requested')
+
+        # Create ticket
+        ticket = f'{self.name}_{self.metadata_counter}'
+
+        if not self.bypass_metadata:
             # Request global metadata (exclude self, we do that locally instead)
             if not self.monitor.connected:
                 self.logger.error("Not connected to monitor! Cannot request metadata!")
             else:
-                self.monitor.request_meta(request_ID=self.name, exclude_list=[self.name])
+                self.monitor.request_meta(request_ID=ticket, exclude_list=[self.name])
 
-            # Local metadata
-            self.localmeta = self.get_meta()
-            self.localmeta['acquisition_start'] = now()
-        self.logger.debug('Metadata loop completed')
+        # Local metadata
+        localmeta = self.get_meta()
+        localmeta['acquisition_start'] = now()
+        self.localmeta[ticket] = localmeta
+        self._last_request_ID = ticket
 
     def frame_management_loop(self):
         """
@@ -471,6 +483,11 @@ class CameraBase(DriverBase):
         """
         Add frame and meta to the queue. This is meant to be called
         within _trigger at least once.
+
+        Parameters:
+        -----------
+        frame: numpy array generated by the detector
+        meta: local metadata created by the detector implementation
         """
         with self.enqueue_lock:
             # Manage end-of-exposure differently
@@ -479,16 +496,25 @@ class CameraBase(DriverBase):
                 self.frame_queue.put((frame, meta))
                 return
 
+            request_ID = self._last_request_ID
+            self._last_request_ID = None
+            if request_ID is None:
+                self.logger.error('In camera.enqueue_frame: last_request_ID should not be None')
+
+            if (not self.bypass_metadata) and (request_ID is not None):
+                if self.monitor.connected:
+                    metadata = self.monitor.return_meta(request_ID)
+                else:
+                    metadata = {}
+
+            # Get metadata
+            localmeta = self.localmeta.pop(request_ID, {})
+
             self.logger.debug('Frame arrived in enqueue_frame')
             self.frame_queue_empty_flag.clear()
 
-            metadata = self.metadata
-            localmeta = self.localmeta
-
-            self.metadata = {}
-            self.localmeta = {}
-
             # Update frame metadata and add to queue
+            localmeta['acquisition_end'] = now()
             localmeta.update(meta)
             metadata[self.name.lower()] = localmeta
 
@@ -705,6 +731,28 @@ class CameraBase(DriverBase):
         super().set_log_level(level)
         #self.frame_writer.set_log_level(level)
         #self.frame_streamer.set_log_level(level)
+
+    @proxycall(admin=True)
+    def set_manager(self, manager_name):
+        """
+        Update the experiment manager for this detector.
+        """
+        # Create new client
+        try:
+            manager = client_or_None(manager_name, inexistent_ok=False, keep_trying=True)
+        except RuntimeError:
+            raise RuntimeError(f'Experiment manager {manager_name} not found!')
+
+        # Close previous one and substitute
+        try:
+            self.manager.disconnect()
+        except AttributeError:
+            pass
+        self.manager = manager
+
+        # Save new config
+        self.config['experiment_manager'] = manager_name
+
 
     def shutdown(self):
         # Stop rolling

--- a/lclib/camera.py
+++ b/lclib/camera.py
@@ -257,6 +257,9 @@ class CameraBase(DriverBase):
 
         self.logger.info(f'Save path: {self.filename}')
 
+        # Get manager metadata - this does not change during exposure
+        self.manager_meta = self.manager.get_meta()
+
         # Trigger next acquisition now
         self.do_acquire.set()
 
@@ -411,11 +414,11 @@ class CameraBase(DriverBase):
         ticket = f'{self.name}_{self.metadata_counter}'
 
         if not self.bypass_metadata:
-            # Request global metadata (exclude self, we do that locally instead)
+            # Request global metadata (exclude self, we do that locally instead; and manager, which was already obtained in snap())
             if not self.monitor.connected:
                 self.logger.error("Not connected to monitor! Cannot request metadata!")
             else:
-                self.monitor.request_meta(request_ID=ticket, exclude_list=[self.name])
+                self.monitor.request_meta(request_ID=ticket, exclude_list=[self.name, self.config['experiment_manager']])
 
         # Local metadata
         localmeta = self.get_meta()
@@ -529,7 +532,8 @@ class CameraBase(DriverBase):
             if request_ID is None:
                 self.logger.error('In camera.enqueue_frame: last_request_ID should not be None')
 
-            metadata = {}
+            # Start at least with manager metadata collected in self.snap
+            metadata = {'manager': self.manager_meta}
             if (not self.bypass_metadata) and (request_ID is not None):
                 if self.monitor.connected:
                     metadata = self.monitor.return_meta(request_ID)

--- a/lclib/camera.py
+++ b/lclib/camera.py
@@ -257,9 +257,6 @@ class CameraBase(DriverBase):
 
         self.logger.info(f'Save path: {self.filename}')
 
-        # Get manager metadata - this does not change during exposure
-        self.manager_meta = self.manager.get_meta()
-
         # Trigger next acquisition now
         self.do_acquire.set()
 
@@ -320,6 +317,9 @@ class CameraBase(DriverBase):
                     self.logger.debug('end_acquisition is True. Breaking out.')
                     break
                 continue
+
+            # Get manager metadata - this does not change during exposure
+            self.manager_meta = self.manager.get_meta()
 
             # Request metadata one time
             if self.bypass_metadata:

--- a/lclib/camera.py
+++ b/lclib/camera.py
@@ -967,6 +967,20 @@ class CameraBase(DriverBase):
         # Call other method to allow subclasses to manage additional side-effects
         self._set_accumulation_number(value)
 
+    @proxycall(admin=True)
+    @property
+    def max_rate_metadata(self):
+        """
+        Maximum rate for metadata collection
+        """
+        return self.config['max_rate_metadata']
+
+    @max_rate_metadata.setter
+    def max_rate_metadata(self, value):
+        value = float(value)
+        if value > self.MAX_RATE_METADATA:
+            raise RuntimeError(f'Rate {value} too high (maximum value: {self.MAX_RATE_METADATA})')
+        self.config['max_rate_metadata'] = value
 
     @proxycall(admin=True)
     @property

--- a/lclib/monitor.py
+++ b/lclib/monitor.py
@@ -286,8 +286,10 @@ class MonitorBase(DriverBase):
     @meta_max_rate.setter
     def meta_max_rate(self, value):
         value = float(value)
-        assert value > 0.
-        assert value < self.META_MAX_RATE_MAX
+        if value < 0.:
+            raise ValueError("meta_max_rate must be greater than 0.")
+        if value >= self.META_MAX_RATE_MAX:
+            raise ValueError(f"meta_max_rate must be less than {self.META_MAX_RATE_MAX}.")
         self.config['meta_max_rate'] = value
 
     @property

--- a/lclib/monitor.py
+++ b/lclib/monitor.py
@@ -173,7 +173,7 @@ class MonitorBase(DriverBase):
             self.logger.warning(f'Empty request: {request_ID}!')
 
         # Grab all available metadata
-        meta = {}
+        meta = {'monitor': {'throttled': False}}
         times = {}
         for name, future in request.items():
             if not future.done():

--- a/lclib/monitor.py
+++ b/lclib/monitor.py
@@ -106,7 +106,7 @@ class MonitorBase(DriverBase):
         """
         client = self.clients.get(name)
         if client is None or not client.connected:
-            self.logger.warning(f'Client {name}: no metadata available.')
+            self.logger.debug(f'Client {name}: no metadata available.')
             return None
         t0 = time.time()
         meta = client.get_meta()

--- a/lclib/monitor.py
+++ b/lclib/monitor.py
@@ -51,6 +51,8 @@ class MonitorBase(DriverBase):
     """
 
     DEFAULT_CONFIG = DriverBase.DEFAULT_CONFIG.copy()
+    DEFAULT_CONFIG.update({'meta_max_rate': 2.})
+    META_MAX_RATE_MAX = 20 # Hard-coded maximum rate for number of meta fetches per second.
 
     def __init__(self):
         """
@@ -93,6 +95,11 @@ class MonitorBase(DriverBase):
         # This is used for stats
         self.connected = True
 
+        # Cache and time stamp for metadata request throttling
+        self.meta_cache = None
+        self.meta_time = 0.
+        self.throttled_requests = []
+
     def fetch_meta(self, name):
         """
         Method run on a short-lived thread just the time to fetch metadata.
@@ -131,8 +138,14 @@ class MonitorBase(DriverBase):
         if include_list is None:
             include_list = [name for name in self.clients.keys() if name not in exclude_list]
 
-        # Fetch metadata on separate threads
-        self.requests[request_ID] = {name:Future(self.fetch_meta, (name,)) for name in include_list}
+        t = time.time()
+        if (t - self.meta_time) < self.meta_interval:
+            # Throttle: two calls were made too close to each other
+            self.throttled_requests.append(request_ID)
+        else:
+            # Fetch metadata on separate threads
+            self.meta_time = t
+            self.requests[request_ID] = {name:Future(self.fetch_meta, (name,)) for name in include_list}        
         return
 
     @proxycall()
@@ -146,6 +159,11 @@ class MonitorBase(DriverBase):
         Returns:
             A dictionary with all metadata.
         """
+        # If the request was throttled, return the latest acquired metadata
+        if request_ID in self.throttled_requests:
+            self.throttled_requests.remove(request_ID)
+            return self.meta_cache
+
         if request_ID not in self.requests:
             self.logger.error(f'Unknown request ID {request_ID}!')
 
@@ -167,6 +185,10 @@ class MonitorBase(DriverBase):
                     meta[name] = result['meta']
                     times[name] = result['time']
 
+        # Store metadata to return in case of future throttling
+        self.meta_cache = {}
+        self.meta_cache.update(meta)
+        self.meta_cache['monitor'] = {'throttled': True}
         return meta
 
     @proxycall(admin=True)
@@ -252,3 +274,26 @@ class MonitorBase(DriverBase):
                             'N': N}
             stats[name] = client_stats
         return stats
+    
+    @proxycall(admin=True)
+    @property
+    def meta_max_rate(self):
+        """
+        Maximum rate at which metadata should be fetched. (Throttling)
+        """
+        return self.config['meta_max_rate']
+
+    @meta_max_rate.setter
+    def meta_max_rate(self, value):
+        value = float(value)
+        assert value > 0.
+        assert value < self.META_MAX_RATE_MAX
+        self.config['meta_max_rate'] = value
+
+    @property
+    def meta_interval(self):
+        rate = self.meta_max_rate
+        if rate == 0.:
+            return 1e7
+        else:
+            return 1./rate

--- a/lclib/util/frameconsumer/frameconsumer.py
+++ b/lclib/util/frameconsumer/frameconsumer.py
@@ -123,8 +123,14 @@ class HDF5Worker(FrameWorker):
             item: (data, meta)
         """
         data, meta = item
-        self.frames.append(data)
-        self.meta.append(meta)
+        # Special case: empty frame but metadata present:
+        # In this case, we update the first metadata.
+        if data is None:
+            if (meta is not None) and self.meta:
+                self.meta[0].update(meta)
+        else:
+            self.frames.append(data)
+            self.meta.append(meta)
 
     def _finalize(self):
         """
@@ -156,6 +162,9 @@ class StreamWorker(FrameWorker):
             item: (data, meta)
         """
         data, meta = item
+        if data is None:
+            self.logger.info('Ignoring empty frame')
+            return
         self.logger.debug('Publishing new frame')
         self.broadcaster.pub(data, meta)
         self.logger.debug('Done publishing new frame')


### PR DESCRIPTION
Implements metadata throttling to avoid overloading the network for very high frame rates. This could be fine-grained on a per-driver basis (for instance if metadata from one driver is needed at high frame rate or some drivers return metadata not supposed to change during a scan).  